### PR TITLE
Use strdisplaywidth instead of s/./x/g

### DIFF
--- a/ftplugin/csv.vim
+++ b/ftplugin/csv.vim
@@ -595,9 +595,7 @@ fu! <sid>ColWidth(colnr, ...) "{{{3
             for item in b:csv_list
                 call add(tlist, get(item, a:colnr-1, ''))
             endfor
-            " do not strip leading whitespace
-            call map(tlist, 'substitute(v:val, ".", "x", "g")')
-            call map(tlist, 'strlen(v:val)')
+            call map(tlist, 'strdisplaywidth(v:val)')
             return max(tlist)
         catch
             throw "ColWidth-error"


### PR DESCRIPTION
I'm a Japanese user of your useful CSV plugin.

When I'm editing .csv files which includes Japanese (multi-byte) characters,
the results of `:ArrangeColumn` were ill because of the mismatch of estimated string width within the column.

I replaced the logic of counting with the built-in function `strdisplaywidth(v:val)`.
Then `:ArrangeColumn` worked very well.

Additionally, the comment `" do not strip leading whitespace` can be fulfilled by this change.

Thank you.

Before:
<img width="413" alt="before" src="https://user-images.githubusercontent.com/11067619/40825254-07d939e8-65b2-11e8-984e-808b0d635f0d.png">

After:
<img width="409" alt="after" src="https://user-images.githubusercontent.com/11067619/40825258-09ff3e84-65b2-11e8-99bd-650f12e95953.png">
